### PR TITLE
Fixed UPF build failure due to BESS dependency branch change - 2

### DIFF
--- a/.github/workflows/cdac-master.yml
+++ b/.github/workflows/cdac-master.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build PTF image
-        run: make build
+        run: make build -f Makefile_CDAC
 
   lint:
     name: lint

--- a/.github/workflows/cdac-master.yml
+++ b/.github/workflows/cdac-master.yml
@@ -193,6 +193,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      
+      - run: echo GIT_SHA_SHORT=$(git rev-parse --short HEAD) >> $GITHUB_ENV
 
       - uses: docker/login-action@v3.2.0
         with:
@@ -202,7 +204,7 @@ jobs:
 
       - name: Build and push release Docker image
         env:
-          DOCKER_TAG: rel-${{ needs.tag-github.outputs.version }}-haswell
+          DOCKER_TAG: master-haswell-${{ env.GIT_SHA_SHORT }}
           CPU: haswell
         run: |
           CPU=$CPU make docker-build -f Makefile_CDAC
@@ -210,10 +212,8 @@ jobs:
 
       - name: Build and push release Docker image for Ivybridge CPU
         env:
-          DOCKER_TAG: rel-${{ needs.tag-github.outputs.version }}-ivybridge
+          DOCKER_TAG: mater-ivybridge-${{ env.GIT_SHA_SHORT }}
           CPU: ivybridge
         run: |
           CPU=$CPU make docker-build -f Makefile_CDAC
           make docker-push -f Makefile_CDAC
-    
-   

--- a/.github/workflows/iosmcn-master.yml
+++ b/.github/workflows/iosmcn-master.yml
@@ -193,6 +193,8 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - run: echo GIT_SHA_SHORT=$(git rev-parse --short HEAD) >> $GITHUB_ENV
+
       - uses: docker/login-action@v3.2.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -201,7 +203,7 @@ jobs:
 
       - name: Build and push release Docker image
         env:
-          DOCKER_TAG: rel-${{ needs.tag-github.outputs.version }}
+          DOCKER_TAG: master-haswell-${{ env.GIT_SHA_SHORT }}
           CPU: haswell
         run: |
           CPU=$CPU make docker-build -f Makefile_IOSMCN
@@ -209,10 +211,8 @@ jobs:
 
       - name: Build and push release Docker image for Ivybridge CPU
         env:
-          DOCKER_TAG: rel-${{ needs.tag-github.outputs.version }}-ivybridge
+          DOCKER_TAG: mater-ivybridge-${{ env.GIT_SHA_SHORT }}
           CPU: ivybridge
         run: |
           CPU=$CPU make docker-build -f Makefile_IOSMCN
           make docker-push -f Makefile_IOSMCN
-    
-   

--- a/.github/workflows/iosmcn-master.yml
+++ b/.github/workflows/iosmcn-master.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build PTF image
-        run: make build
+        run: make build -f Makefile_IOSMCN
 
   lint:
     name: lint

--- a/Dockerfile_CDAC
+++ b/Dockerfile_CDAC
@@ -3,7 +3,7 @@
 # Copyright 2019-present Intel Corporation
 
 # Stage bess-build: fetch BESS dependencies & pre-reqs
-FROM docker.io/cdac5gc/bess_build:latest:latest AS bess-build
+FROM docker.io/cdac5gc/bess_build:latest AS bess-build
 ARG CPU=native
 ARG BESS_COMMIT=cdacmaster
 ENV PLUGINS_DIR=plugins

--- a/Dockerfile_CDAC
+++ b/Dockerfile_CDAC
@@ -53,7 +53,7 @@ RUN PLUGINS=$(find "$PLUGINS_DIR" -mindepth 1 -maxdepth 1 -type d) && \
     cp -r core/pb /pb
 
 # Stage bess: creates the runtime image of BESS
-FROM ubuntu:22.04 AS bess
+FROM ubuntu:24.04 AS bess
 WORKDIR /
 COPY requirements.txt .
 RUN apt-get update && apt-get install -y \
@@ -66,7 +66,7 @@ RUN apt-get update && apt-get install -y \
     tcpdump && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir --break-system-packages -r requirements.txt
 COPY --from=bess-build /opt/bess /opt/bess
 COPY --from=bess-build /bin/bessd /bin/bessd
 COPY --from=bess-build /bin/modules /bin/modules
@@ -102,7 +102,7 @@ WORKDIR /opt/bess/bessctl
 ENTRYPOINT ["bessd", "-f"]
 
 # Stage build bess golang pb
-FROM golang:1.22.2 AS protoc-gen
+FROM golang:1.22.3 AS protoc-gen
 RUN go install github.com/golang/protobuf/protoc-gen-go@latest
 
 FROM bess-build AS go-pb
@@ -115,12 +115,12 @@ RUN mkdir /bess_pb && \
 FROM bess-build AS py-pb
 RUN pip install --no-cache-dir grpcio-tools==1.26
 RUN mkdir /bess_pb && \
-    python -m grpc_tools.protoc -I /usr/include -I /protobuf/ \
+    python3 -m grpc_tools.protoc -I /usr/include -I /protobuf/ \
     /protobuf/*.proto /protobuf/ports/*.proto \
     --python_out=plugins=grpc:/bess_pb \
     --grpc_python_out=/bess_pb
 
-FROM golang:1.22.2 AS pfcpiface-build
+FROM golang:1.22.3 AS pfcpiface-build
 ARG GOFLAGS
 WORKDIR /pfcpiface
 
@@ -134,7 +134,7 @@ COPY . /pfcpiface
 RUN CGO_ENABLED=0 go build $GOFLAGS -o /bin/pfcpiface ./cmd/pfcpiface
 
 # Stage pfcpiface: runtime image of pfcpiface toward SMF/SPGW-C
-FROM alpine:3.19.1 AS pfcpiface
+FROM alpine:3.20.0 AS pfcpiface
 COPY conf /opt/bess/bessctl/conf
 COPY --from=pfcpiface-build /bin/pfcpiface /bin
 ENTRYPOINT [ "/bin/pfcpiface" ]

--- a/Dockerfile_IOSMCN
+++ b/Dockerfile_IOSMCN
@@ -53,7 +53,7 @@ RUN PLUGINS=$(find "$PLUGINS_DIR" -mindepth 1 -maxdepth 1 -type d) && \
     cp -r core/pb /pb
 
 # Stage bess: creates the runtime image of BESS
-FROM ubuntu:22.04 AS bess
+FROM ubuntu:24.04 AS bess
 WORKDIR /
 COPY requirements.txt .
 RUN apt-get update && apt-get install -y \
@@ -66,7 +66,7 @@ RUN apt-get update && apt-get install -y \
     tcpdump && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir --break-system-packages -r requirements.txt
 COPY --from=bess-build /opt/bess /opt/bess
 COPY --from=bess-build /bin/bessd /bin/bessd
 COPY --from=bess-build /bin/modules /bin/modules
@@ -102,7 +102,7 @@ WORKDIR /opt/bess/bessctl
 ENTRYPOINT ["bessd", "-f"]
 
 # Stage build bess golang pb
-FROM golang:1.22.2 AS protoc-gen
+FROM golang:1.22.3 AS protoc-gen
 RUN go install github.com/golang/protobuf/protoc-gen-go@latest
 
 FROM bess-build AS go-pb
@@ -115,12 +115,12 @@ RUN mkdir /bess_pb && \
 FROM bess-build AS py-pb
 RUN pip install --no-cache-dir grpcio-tools==1.26
 RUN mkdir /bess_pb && \
-    python -m grpc_tools.protoc -I /usr/include -I /protobuf/ \
+    python3 -m grpc_tools.protoc -I /usr/include -I /protobuf/ \
     /protobuf/*.proto /protobuf/ports/*.proto \
     --python_out=plugins=grpc:/bess_pb \
     --grpc_python_out=/bess_pb
 
-FROM golang:1.22.2 AS pfcpiface-build
+FROM golang:1.22.3 AS pfcpiface-build
 ARG GOFLAGS
 WORKDIR /pfcpiface
 
@@ -134,7 +134,7 @@ COPY . /pfcpiface
 RUN CGO_ENABLED=0 go build $GOFLAGS -o /bin/pfcpiface ./cmd/pfcpiface
 
 # Stage pfcpiface: runtime image of pfcpiface toward SMF/SPGW-C
-FROM alpine:3.19.1 AS pfcpiface
+FROM alpine:3.20.0 AS pfcpiface
 COPY conf /opt/bess/bessctl/conf
 COPY --from=pfcpiface-build /bin/pfcpiface /bin
 ENTRYPOINT [ "/bin/pfcpiface" ]

--- a/ptf/Dockerfile_CDAC
+++ b/ptf/Dockerfile_CDAC
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2021 Open Networking Foundation
+
+# Docker image to run PTF-based tests
+
+ARG SCAPY_VER=2.4.5
+ARG PTF_VER=c5299ea2e27386653209af458757b3b15e5dec5d
+ARG TREX_VER=2.92-scapy-2.4.5
+ARG TREX_EXT_LIBS=/external_libs
+ARG TREX_LIBS=/trex_python
+ARG UNITTEST_XML_REPORTING_VER=3.0.4
+ARG PROTOBUF_VER=3.20
+# Install dependencies for general PTF test definitions
+FROM ubuntu:22.04 as ptf-deps
+
+ARG SCAPY_VER
+ARG PTF_VER
+ARG UNITTEST_XML_REPORTING_VER
+ARG PROTOBUF_VER
+ARG GRPC_VER
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+    git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --no-cache-dir --root /python_output \
+    git+https://github.com/p4lang/ptf@$PTF_VER \
+    protobuf==$PROTOBUF_VER \
+    grpcio \
+    unittest-xml-reporting==$UNITTEST_XML_REPORTING_VER
+
+# Install TRex traffic gen and library for TRex API
+FROM alpine:3.20.0 as trex-builder
+ARG TREX_VER
+ARG TREX_EXT_LIBS
+ARG TREX_LIBS
+
+ENV TREX_SCRIPT_DIR=/trex-core-${TREX_VER}/scripts
+
+RUN apk update && apk add --no-cache -U wget && \
+    wget https://github.com/stratum/trex-core/archive/v${TREX_VER}.zip && \
+    unzip -qq v${TREX_VER}.zip && \
+    mkdir -p /output/${TREX_EXT_LIBS} && \
+    mkdir -p /output/${TREX_LIBS} && \
+    cp -r ${TREX_SCRIPT_DIR}/automation/trex_control_plane/interactive/* /output/${TREX_LIBS} && \
+    cp -r ${TREX_SCRIPT_DIR}/external_libs/* /output/${TREX_EXT_LIBS} && \
+    cp -r ${TREX_SCRIPT_DIR}/automation/trex_control_plane/stf/trex_stf_lib /output/${TREX_LIBS}
+
+# Synthesize all dependencies for runtime
+FROM ubuntu:22.04
+
+ARG TREX_EXT_LIBS
+ARG TREX_LIBS
+ARG SCAPY_VER
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    make \
+    net-tools \
+    python3 \
+    python3-setuptools \
+    iproute2 \
+    tcpdump \
+    dumb-init \
+    python3-dev \
+    build-essential \
+    python3-pip \
+    wget \
+    netbase && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+RUN pip3 install --no-cache-dir \
+    scipy \
+    numpy \
+    matplotlib \
+    pyyaml
+
+ENV TREX_EXT_LIBS=${TREX_EXT_LIBS}
+ENV PYTHONPATH=${TREX_EXT_LIBS}:${TREX_LIBS}
+
+COPY --from=trex-builder /output /
+COPY --from=ptf-deps /python_output /
+
+# Install custom scapy version from TRex so PTF tests can access certain scapy features
+# TODO: Move to a newer Scapy version compatible with latest Ubuntu versions
+WORKDIR ${TREX_EXT_LIBS}/scapy-${SCAPY_VER}
+RUN python3 setup.py install \
+    && ldconfig
+
+ENTRYPOINT []

--- a/ptf/Dockerfile_IOSMCN
+++ b/ptf/Dockerfile_IOSMCN
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2021 Open Networking Foundation
+
+# Docker image to run PTF-based tests
+
+ARG SCAPY_VER=2.4.5
+ARG PTF_VER=c5299ea2e27386653209af458757b3b15e5dec5d
+ARG TREX_VER=2.92-scapy-2.4.5
+ARG TREX_EXT_LIBS=/external_libs
+ARG TREX_LIBS=/trex_python
+ARG UNITTEST_XML_REPORTING_VER=3.0.4
+ARG PROTOBUF_VER=3.20
+# Install dependencies for general PTF test definitions
+FROM ubuntu:22.04 as ptf-deps
+
+ARG SCAPY_VER
+ARG PTF_VER
+ARG UNITTEST_XML_REPORTING_VER
+ARG PROTOBUF_VER
+ARG GRPC_VER
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+    git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --no-cache-dir --root /python_output \
+    git+https://github.com/p4lang/ptf@$PTF_VER \
+    protobuf==$PROTOBUF_VER \
+    grpcio \
+    unittest-xml-reporting==$UNITTEST_XML_REPORTING_VER
+
+# Install TRex traffic gen and library for TRex API
+FROM alpine:3.20.0 as trex-builder
+ARG TREX_VER
+ARG TREX_EXT_LIBS
+ARG TREX_LIBS
+
+ENV TREX_SCRIPT_DIR=/trex-core-${TREX_VER}/scripts
+
+RUN apk update && apk add --no-cache -U wget && \
+    wget https://github.com/stratum/trex-core/archive/v${TREX_VER}.zip && \
+    unzip -qq v${TREX_VER}.zip && \
+    mkdir -p /output/${TREX_EXT_LIBS} && \
+    mkdir -p /output/${TREX_LIBS} && \
+    cp -r ${TREX_SCRIPT_DIR}/automation/trex_control_plane/interactive/* /output/${TREX_LIBS} && \
+    cp -r ${TREX_SCRIPT_DIR}/external_libs/* /output/${TREX_EXT_LIBS} && \
+    cp -r ${TREX_SCRIPT_DIR}/automation/trex_control_plane/stf/trex_stf_lib /output/${TREX_LIBS}
+
+# Synthesize all dependencies for runtime
+FROM ubuntu:22.04
+
+ARG TREX_EXT_LIBS
+ARG TREX_LIBS
+ARG SCAPY_VER
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    make \
+    net-tools \
+    python3 \
+    python3-setuptools \
+    iproute2 \
+    tcpdump \
+    dumb-init \
+    python3-dev \
+    build-essential \
+    python3-pip \
+    wget \
+    netbase && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+RUN pip3 install --no-cache-dir \
+    scipy \
+    numpy \
+    matplotlib \
+    pyyaml
+
+ENV TREX_EXT_LIBS=${TREX_EXT_LIBS}
+ENV PYTHONPATH=${TREX_EXT_LIBS}:${TREX_LIBS}
+
+COPY --from=trex-builder /output /
+COPY --from=ptf-deps /python_output /
+
+# Install custom scapy version from TRex so PTF tests can access certain scapy features
+# TODO: Move to a newer Scapy version compatible with latest Ubuntu versions
+WORKDIR ${TREX_EXT_LIBS}/scapy-${SCAPY_VER}
+RUN python3 setup.py install \
+    && ldconfig
+
+ENTRYPOINT []

--- a/ptf/Makefile_CDAC
+++ b/ptf/Makefile_CDAC
@@ -3,7 +3,7 @@
 
 # generates python protobuf files and builds ptf docker image
 build: 
-	cd .. && make py-pb
+	cd .. && make py-pb -f Makefile_CDAC
 	docker build -f Dockerfile_CDAC -t bess-upf-ptf .
 
 # removes generated python protobuf files

--- a/ptf/Makefile_CDAC
+++ b/ptf/Makefile_CDAC
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020-present Open Networking Foundation
+
+# generates python protobuf files and builds ptf docker image
+build: 
+	cd .. && make py-pb
+	docker build -f Dockerfile_CDAC -t bess-upf-ptf .
+
+# removes generated python protobuf files
+clean:
+	rm -v lib/*pb2*
+	rm -rvf lib/ports/

--- a/ptf/Makefile_IOSMCN
+++ b/ptf/Makefile_IOSMCN
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020-present Open Networking Foundation
+
+# generates python protobuf files and builds ptf docker image
+build: 
+	cd .. && make py-pb
+	docker build -f Dockerfile_IOSMCN -t bess-upf-ptf .
+
+# removes generated python protobuf files
+clean:
+	rm -v lib/*pb2*
+	rm -rvf lib/ports/

--- a/ptf/Makefile_IOSMCN
+++ b/ptf/Makefile_IOSMCN
@@ -3,7 +3,7 @@
 
 # generates python protobuf files and builds ptf docker image
 build: 
-	cd .. && make py-pb
+	cd .. && make py-pb -f Makefile_IOSMCN
 	docker build -f Dockerfile_IOSMCN -t bess-upf-ptf .
 
 # removes generated python protobuf files


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug fix
> /kind enhancement

**What this PR does / why we need it**:
This PR updates the Docker build commands to point to our own CDAC and IOSMCN organization Docker files. The BESS_COMMIT variable has been updated to cdacmaster and iosmcnmaster to ensure stable, organization-managed dependencies. 
Additionally:
1. Separated Makefiles and Dockerfiles specifically for the PTF (Packet Test Framework) build job to streamline and manage the PTF build independently.
2. Modified the Docker image tag naming convention to master-(CPU name)-(Git commit hash) for clearer version tracking and identification.

These changes are essential to resolve the UPF build failure caused by branch changes in the OMEC repository and to support efficient PTF builds.

**Which issue(s) this PR fixes**:
Fixes #9 

**Test Report Added?**:
> /kind NOT-TESTED

**Test Report**:
NA

**Special notes for your reviewer**:
NIL