### PR TITLE
Fix Docker image naming typo: "mater-ivybridge" to "master-ivybridge"

### DIFF
--- a/.github/workflows/cdac-master.yml
+++ b/.github/workflows/cdac-master.yml
@@ -212,7 +212,7 @@ jobs:
 
       - name: Build and push release Docker image for Ivybridge CPU
         env:
-          DOCKER_TAG: mater-ivybridge-${{ env.GIT_SHA_SHORT }}
+          DOCKER_TAG: master-ivybridge-${{ env.GIT_SHA_SHORT }}
           CPU: ivybridge
         run: |
           CPU=$CPU make docker-build -f Makefile_CDAC

--- a/.github/workflows/iosmcn-master.yml
+++ b/.github/workflows/iosmcn-master.yml
@@ -211,7 +211,7 @@ jobs:
 
       - name: Build and push release Docker image for Ivybridge CPU
         env:
-          DOCKER_TAG: mater-ivybridge-${{ env.GIT_SHA_SHORT }}
+          DOCKER_TAG: master-ivybridge-${{ env.GIT_SHA_SHORT }}
           CPU: ivybridge
         run: |
           CPU=$CPU make docker-build -f Makefile_IOSMCN


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
This PR corrects a typo in the Docker image naming convention. Previously, images were generated with the prefix mater- instead of master-. The updated code ensures that the naming follows the intended format of master-(CPU name)-(Git commit hash), which is essential for accurate tracking and consistency across builds.

**Which issue(s) this PR fixes**:
Fixes #12 

**Test Report Added?**:
> /kind TESTED

**Test Report**:
NA

**Special notes for your reviewer**:
NIL