### PR TITLE
UPF build authentication fix 2

### DIFF
--- a/.github/workflows/cdac-master.yml
+++ b/.github/workflows/cdac-master.yml
@@ -214,7 +214,7 @@ jobs:
           username: ${{ secrets.DCKRUSER }}
           password: ${{ secrets.DCKRPASS }}
 
-      - name: Build and push release Docker image
+      - name: Build and push Docker image for Haswell CPU
         env:
           DOCKER_TAG: master-haswell-${{ env.GIT_SHA_SHORT }}
           CPU: haswell
@@ -222,7 +222,7 @@ jobs:
           CPU=$CPU make docker-build -f Makefile_CDAC
           make docker-push -f Makefile_CDAC
 
-      - name: Build and push release Docker image for Ivybridge CPU
+      - name: Build and push Docker image for Ivybridge CPU
         env:
           DOCKER_TAG: master-ivybridge-${{ env.GIT_SHA_SHORT }}
           CPU: ivybridge

--- a/.github/workflows/cdac-master.yml
+++ b/.github/workflows/cdac-master.yml
@@ -36,14 +36,24 @@ jobs:
   build-ptf:
     if: github.event_name == 'pull_request' && github.repository_owner == '5GC-DEV'
     runs-on: ubuntu-latest
+    env:
+      REGISTRY: docker.io
+      GITHUB_USERNAME: ${{ secrets.DCKRUSER }}
+      GITHUB_TOKEN: ${{ secrets.DCKRPASS }}
     defaults:
       run:
         working-directory: ./ptf
     steps:
       - uses: actions/checkout@v4
+    
+      - uses: docker/login-action@v3.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DCKRUSER }}
+          password: ${{ secrets.DCKRPASS }}
 
       - name: Build PTF image
-        run: make build -f Makefile_CDAC
+        run: make build -f Makefile_CDAC 
 
   lint:
     name: lint

--- a/.github/workflows/cdac-master.yml
+++ b/.github/workflows/cdac-master.yml
@@ -197,6 +197,8 @@ jobs:
       REGISTRY: docker.io
       DOCKER_REGISTRY: docker.io/
       DOCKER_REPOSITORY: cdac5gc/
+      GITHUB_USERNAME: ${{ secrets.DCKRUSER }}
+      GITHUB_TOKEN: ${{ secrets.DCKRPASS }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/iosmcn-master.yml
+++ b/.github/workflows/iosmcn-master.yml
@@ -196,6 +196,8 @@ jobs:
       REGISTRY: ghcr.io
       DOCKER_REGISTRY: ghcr.io/
       DOCKER_REPOSITORY: ios-mcn-core/
+      GITHUB_USERNAME: ${{ secrets.GHCRUSER }}
+      GITHUB_TOKEN: ${{ secrets.GHCRPASS }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/iosmcn-master.yml
+++ b/.github/workflows/iosmcn-master.yml
@@ -35,11 +35,21 @@ jobs:
   build-ptf:
     if: github.event_name == 'pull_request' && github.repository_owner == 'ios-mcn-core'
     runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      GITHUB_USERNAME: ${{ secrets.GHCRUSER }}
+      GITHUB_TOKEN: ${{ secrets.GHCRPASS }}
     defaults:
       run:
         working-directory: ./ptf
     steps:
       - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GHCRUSER }}
+          password: ${{ secrets.GHCRPASS }}
 
       - name: Build PTF image
         run: make build -f Makefile_IOSMCN

--- a/.github/workflows/iosmcn-master.yml
+++ b/.github/workflows/iosmcn-master.yml
@@ -213,7 +213,7 @@ jobs:
           username: ${{ secrets.GHCRUSER }}
           password: ${{ secrets.GHCRPASS }}
 
-      - name: Build and push release Docker image
+      - name: Build and push Docker image for Haswell CPU
         env:
           DOCKER_TAG: master-haswell-${{ env.GIT_SHA_SHORT }}
           CPU: haswell
@@ -221,7 +221,7 @@ jobs:
           CPU=$CPU make docker-build -f Makefile_IOSMCN
           make docker-push -f Makefile_IOSMCN
 
-      - name: Build and push release Docker image for Ivybridge CPU
+      - name: Build and push Docker image for Ivybridge CPU
         env:
           DOCKER_TAG: master-ivybridge-${{ env.GIT_SHA_SHORT }}
           CPU: ivybridge

--- a/Dockerfile_CDAC
+++ b/Dockerfile_CDAC
@@ -20,8 +20,10 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 
 # BESS pre-reqs
+ARG GITHUB_USERNAME
+ARG GITHUB_TOKEN
 WORKDIR /bess
-RUN git clone https://github.com/5GC-DEV/bess-cdac.git . && \
+RUN git clone https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/5GC-DEV/bess-cdac.git . && \
     git checkout ${BESS_COMMIT} && \
     cp -a protobuf /protobuf
 

--- a/Dockerfile_IOSMCN
+++ b/Dockerfile_IOSMCN
@@ -20,8 +20,10 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 
 # BESS pre-reqs
+ARG GITHUB_USERNAME
+ARG GITHUB_TOKEN
 WORKDIR /bess
-RUN git clone https://github.com/ios-mcn-core/bess.git . && \
+RUN git clone https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/ios-mcn-core/bess.git . && \
     git checkout ${BESS_COMMIT} && \
     cp -a protobuf /protobuf
 

--- a/Makefile_CDAC
+++ b/Makefile_CDAC
@@ -49,7 +49,9 @@ docker-build:
 		if [ $(DOCKER_BUILDKIT) = 1 ]; then \
 			DOCKER_CACHE_ARG="--cache-from ${DOCKER_REGISTRY}${DOCKER_REPOSITORY}upf-epc-$$target:${DOCKER_TAG}"; \
 		fi; \
-		DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build -f Dockerfile_CDAC $(DOCKER_PULL) $(DOCKER_BUILD_ARGS) \
+		DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build  -f Dockerfile_CDAC $(DOCKER_PULL) $(DOCKER_BUILD_ARGS) \
+			--build-arg GITHUB_USERNAME=${GITHUB_USERNAME} \
+        	--build-arg GITHUB_TOKEN=${GITHUB_TOKEN} \
 			--target $$target \
 			$$DOCKER_CACHE_ARG \
 			--tag ${DOCKER_REGISTRY}${DOCKER_REPOSITORY}upf-epc-$$target:${DOCKER_TAG} \
@@ -71,6 +73,8 @@ docker-push:
 # Change target to bess-build/pfcpiface to exctract src/obj/bins for performance analysis
 output:
 	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build -f Dockerfile_CDAC $(DOCKER_PULL) $(DOCKER_BUILD_ARGS) \
+		--build-arg GITHUB_USERNAME=${GITHUB_USERNAME} \
+        --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} \
 		--target artifacts \
 		--output type=tar,dest=output.tar \
 		.;
@@ -93,6 +97,8 @@ test-bess-integration-native:
 
 pb:
 	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build -f Dockerfile_CDAC $(DOCKER_PULL) $(DOCKER_BUILD_ARGS) \
+		--build-arg GITHUB_USERNAME=${GITHUB_USERNAME} \
+        --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} \
 		--target pb \
 		--output output \
 		.;
@@ -101,6 +107,8 @@ pb:
 # Python grpc/protobuf generation
 py-pb:
 	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build -f Dockerfile_CDAC $(DOCKER_PULL) $(DOCKER_BUILD_ARGS) \
+		--build-arg GITHUB_USERNAME=${GITHUB_USERNAME} \
+        --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} \
 		--target ptf-pb \
 		--output output \
 		.;

--- a/Makefile_IOSMCN
+++ b/Makefile_IOSMCN
@@ -50,6 +50,8 @@ docker-build:
 			DOCKER_CACHE_ARG="--cache-from ${DOCKER_REGISTRY}${DOCKER_REPOSITORY}upf-epc-$$target:${DOCKER_TAG}"; \
 		fi; \
 		DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build -f Dockerfile_IOSMCN $(DOCKER_PULL) $(DOCKER_BUILD_ARGS) \
+			--build-arg GITHUB_USERNAME=${GITHUB_USERNAME} \
+        	--build-arg GITHUB_TOKEN=${GITHUB_TOKEN} \
 			--target $$target \
 			$$DOCKER_CACHE_ARG \
 			--tag ${DOCKER_REGISTRY}${DOCKER_REPOSITORY}upf-epc-$$target:${DOCKER_TAG} \
@@ -71,6 +73,8 @@ docker-push:
 # Change target to bess-build/pfcpiface to exctract src/obj/bins for performance analysis
 output:
 	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build -f Dockerfile_IOSMCN $(DOCKER_PULL) $(DOCKER_BUILD_ARGS) \
+		--build-arg GITHUB_USERNAME=${GITHUB_USERNAME} \
+        --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} \
 		--target artifacts \
 		--output type=tar,dest=output.tar \
 		.;
@@ -93,6 +97,8 @@ test-bess-integration-native:
 
 pb:
 	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build -f Dockerfile_IOSMCN $(DOCKER_PULL) $(DOCKER_BUILD_ARGS) \
+		--build-arg GITHUB_USERNAME=${GITHUB_USERNAME} \
+        --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} \
 		--target pb \
 		--output output \
 		.;
@@ -101,6 +107,8 @@ pb:
 # Python grpc/protobuf generation
 py-pb:
 	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build -f Dockerfile_IOSMCN $(DOCKER_PULL) $(DOCKER_BUILD_ARGS) \
+		--build-arg GITHUB_USERNAME=${GITHUB_USERNAME} \
+        --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} \
 		--target ptf-pb \
 		--output output \
 		.;

--- a/ptf/Makefile_CDAC
+++ b/ptf/Makefile_CDAC
@@ -4,7 +4,10 @@
 # generates python protobuf files and builds ptf docker image
 build: 
 	cd .. && make py-pb -f Makefile_CDAC
-	docker build -f Dockerfile_CDAC -t bess-upf-ptf .
+	docker build -f Dockerfile_CDAC \
+	--build-arg GITHUB_USERNAME=${GITHUB_USERNAME} \
+    --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} \
+	-t bess-upf-ptf .
 
 # removes generated python protobuf files
 clean:

--- a/ptf/Makefile_IOSMCN
+++ b/ptf/Makefile_IOSMCN
@@ -4,7 +4,10 @@
 # generates python protobuf files and builds ptf docker image
 build: 
 	cd .. && make py-pb -f Makefile_IOSMCN
-	docker build -f Dockerfile_IOSMCN -t bess-upf-ptf .
+	docker build -f Dockerfile_IOSMCN \
+	--build-arg GITHUB_USERNAME=${GITHUB_USERNAME} \
+    --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} \
+	-t bess-upf-ptf .
 
 # removes generated python protobuf files
 clean:


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
This PR adds a Docker login step to the build-ptf job in the UPF build process for the IOSMCN organization. The login is required to authenticate and access private Docker images, addressing the 401 Unauthorized error.

**Which issue(s) this PR fixes**:
Fixes #15 

**Test Report Added?**:
> /kind NOT-TESTED

**Test Report**:
NIL

**Special notes for your reviewer**:
NIL