### PR TITLE
Release workflow failure fix

### DIFF
--- a/.github/workflows/cdac-release-push.yml
+++ b/.github/workflows/cdac-release-push.yml
@@ -15,6 +15,8 @@ jobs:
       REGISTRY: docker.io
       DOCKER_REGISTRY: docker.io/
       DOCKER_REPOSITORY: cdac5gc/
+      GITHUB_USERNAME: ${{ secrets.DCKRUSER }}
+      GITHUB_TOKEN: ${{ secrets.DCKRPASS }}
       RELEASE_VERSION: 0.0.3
       
     steps:

--- a/.github/workflows/iosmcn-release-push.yml
+++ b/.github/workflows/iosmcn-release-push.yml
@@ -15,6 +15,8 @@ jobs:
       REGISTRY: ghcr.io
       DOCKER_REGISTRY: ghcr.io/
       DOCKER_REPOSITORY: ios-mcn-core/
+      GITHUB_USERNAME: ${{ secrets.GHCRUSER }}
+      GITHUB_TOKEN: ${{ secrets.GHCRPASS }}
       RELEASE_VERSION: 0.0.3
       
     steps:


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
This PR adds the necessary GITHUB_USERNAME and GITHUB_TOKEN environment variables to the docker push job in the release workflow. These credentials are required for authentication, enabling the workflow to push Docker images successfully.

**Which issue(s) this PR fixes**:
Fixes #20 

**Test Report Added?**:
> /kind NOT-TESTED

**Test Report**:
NA

**Special notes for your reviewer**:
NIL