### PR TITLE
Fix: PFCP Association Release Request Not Rejected for Invalid Node ID

### DIFF
--- a/.github/workflows/cdac-master.yml
+++ b/.github/workflows/cdac-master.yml
@@ -69,7 +69,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8.0.0
         with:
-          version: latest
+          version: v2.2.2
           args: -v --config ./.golangci.yml --timeout=10m
 
   hadolint:

--- a/.github/workflows/iosmcn-master.yml
+++ b/.github/workflows/iosmcn-master.yml
@@ -68,7 +68,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8.0.0
         with:
-          version: latest
+          version: v2.2.2
           args: --v --config ./.golangci.yml --timeout=10m
 
   hadolint:

--- a/Dockerfile_CDAC
+++ b/Dockerfile_CDAC
@@ -5,7 +5,7 @@
 # Stage bess-build: fetch BESS dependencies & pre-reqs
 FROM docker.io/cdac5gc/bess_build:latest AS bess-build
 ARG CPU=native
-ARG BESS_COMMIT=cdacmaster
+ARG BESS_COMMIT=ubuntu-version-change
 ENV PLUGINS_DIR=plugins
 ARG MAKEFLAGS
 ENV PKG_CONFIG_PATH=/usr/lib64/pkgconfig
@@ -55,7 +55,7 @@ RUN PLUGINS=$(find "$PLUGINS_DIR" -mindepth 1 -maxdepth 1 -type d) && \
     cp -r core/pb /pb
 
 # Stage bess: creates the runtime image of BESS
-FROM ubuntu:24.04 AS bess
+FROM ubuntu:22.04 AS bess
 WORKDIR /
 COPY requirements.txt .
 RUN apt-get update && apt-get install -y \
@@ -68,7 +68,7 @@ RUN apt-get update && apt-get install -y \
     tcpdump && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install --no-cache-dir --break-system-packages -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt
 COPY --from=bess-build /opt/bess /opt/bess
 COPY --from=bess-build /bin/bessd /bin/bessd
 COPY --from=bess-build /bin/modules /bin/modules

--- a/Dockerfile_CDAC
+++ b/Dockerfile_CDAC
@@ -3,9 +3,9 @@
 # Copyright 2019-present Intel Corporation
 
 # Stage bess-build: fetch BESS dependencies & pre-reqs
-FROM docker.io/cdac5gc/bess_build:latest AS bess-build
+FROM docker.io/cdac5gc/bess_build:release-0.0.2 AS bess-build
 ARG CPU=native
-ARG BESS_COMMIT=ubuntu-version-change
+ARG BESS_COMMIT=cdacmaster
 ENV PLUGINS_DIR=plugins
 ARG MAKEFLAGS
 ENV PKG_CONFIG_PATH=/usr/lib64/pkgconfig
@@ -55,7 +55,7 @@ RUN PLUGINS=$(find "$PLUGINS_DIR" -mindepth 1 -maxdepth 1 -type d) && \
     cp -r core/pb /pb
 
 # Stage bess: creates the runtime image of BESS
-FROM ubuntu:22.04 AS bess
+FROM ubuntu:24.04 AS bess
 WORKDIR /
 COPY requirements.txt .
 RUN apt-get update && apt-get install -y \
@@ -68,7 +68,7 @@ RUN apt-get update && apt-get install -y \
     tcpdump && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir --break-system-packages -r requirements.txt
 COPY --from=bess-build /opt/bess /opt/bess
 COPY --from=bess-build /bin/bessd /bin/bessd
 COPY --from=bess-build /bin/modules /bin/modules

--- a/pfcpiface/messages_conn.go
+++ b/pfcpiface/messages_conn.go
@@ -228,12 +228,62 @@ func (pConn *PFCPConn) handleAssociationReleaseRequest(msg message.Message) (mes
 		return nil, errUnmarshal(errMsgUnexpectedType)
 	}
 
-	// Build response message
+	// Check if NodeID IE is missing
+	if arreq.NodeID == nil {
+		logger.PfcpLog.Errorln("Association Release Request missing mandatory NodeID IE")
+
+		arres := message.NewAssociationReleaseResponse(arreq.SequenceNumber,
+			pConn.nodeID.localIE,
+			ie.NewCause(ie.CauseMandatoryIEMissing),
+			//ie.NewOffendingIE(ie.NodeID),
+		)
+		return arres, errProcess(errors.New("mandatory IE missing: NodeID"))
+	}
+
+	// Extract NodeID from the incoming request
+	receivedNodeID, err := arreq.NodeID.NodeID()
+	if err != nil {
+		logger.PfcpLog.Errorln("Failed to parse NodeID from Association Release Request:", err)
+
+		arres := message.NewAssociationReleaseResponse(arreq.SequenceNumber,
+			pConn.nodeID.localIE,
+			ie.NewCause(ie.CauseMandatoryIEMissing),
+			//ie.NewOffendingIE(ie.NodeID), // 16 = NodeID
+		)
+		return arres, errUnmarshal(err)
+	}
+
+	// Compare with stored value
+	expectedNodeID := pConn.nodeID.remote
+	if expectedNodeID == "" {
+		logger.PfcpLog.Warnln("No expected NodeID stored — treating as invalid")
+
+		arres := message.NewAssociationReleaseResponse(arreq.SequenceNumber,
+			pConn.nodeID.localIE,
+			ie.NewCause(ie.CauseRequestRejected),
+			//ie.NewOffendingIE(ie.NodeID),
+		)
+		return arres, nil
+	}
+
+	if receivedNodeID != expectedNodeID {
+		logger.PfcpLog.Warnf("NodeID mismatch: got %s, expected %s", receivedNodeID, expectedNodeID)
+
+		arres := message.NewAssociationReleaseResponse(arreq.SequenceNumber,
+			pConn.nodeID.localIE,
+			ie.NewCause(ie.CauseMandatoryIEIncorrect),
+			//ie.NewOffendingIE(16),
+		)
+		return arres, nil
+	}
+
+	// Valid NodeID — send accepted response
 	arres := message.NewAssociationReleaseResponse(arreq.SequenceNumber,
 		//ie.NewRecoveryTimeStamp(pConn.ts.local),
 		pConn.nodeID.localIE,
 		ie.NewCause(ie.CauseRequestAccepted),
 	)
+	logger.PfcpLog.Infoln("Association Release accepted for NodeID:", receivedNodeID)
 
 	return arres, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix

**What this PR does / why we need it**:
When a PFCP Association Release Request is received by the UPF with an invalid Node ID (i.e., a Node ID that does not match any existing PFCP association), the UPF should reject the request. This PR validates the Node ID and sends the correct cause value.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#43](https://github.com/5GC-DEV/upf-cdac/issues/43#issue-3321907585)

**Test Report Added?**:

> /kind TESTED


**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
NA

**Special notes for your reviewer**:
NIL