### PR TITLE
Fix: Send correct cause value for invalid Forwarding Policy ID

### DIFF
--- a/pfcpiface/messages_session.go
+++ b/pfcpiface/messages_session.go
@@ -294,12 +294,38 @@ func (pConn *PFCPConn) handleSessionModificationRequest(msg message.Message) (me
 		addPDRs = append(addPDRs, p)
 	}
 
+	// Iterate through each "Update FAR" instruction in the request.
 	for _, uFAR := range smreq.UpdateFAR {
 		var (
 			f   far
 			err error
 		)
 
+		// Extract the FAR ID from the incoming update instruction.
+		farID, err := uFAR.FARID()
+		if err != nil {
+			// This indicates a malformed IE.
+			return sendError(err, ie.CauseMandatoryIEIncorrect)
+		}
+
+		// Validate that the FAR ID exists before attempting to update it.
+		farExists := false
+		// Since session.fars is a slice, we must loop through it to check for the ID.
+		for _, existingFAR := range session.fars {
+			if existingFAR.farID == farID {
+				farExists = true
+				break // Found it, no need to loop further
+			}
+		}
+
+		// If the FAR ID was not found in the session, the request is invalid.
+		if !farExists {
+			logger.PfcpLog.Warnf("Attempted to update a non-existent FAR ID: %d for local SEID: %d", farID, localSEID)
+			// Reject with "Invalid Forwarding Policy".
+			return sendError(errors.New("invalid forwarding policy: FAR ID not found"), ie.CauseInvalidForwardingPolicy)
+		}
+
+		// Validation passed. Now, parse and apply the update.
 		if err = f.parseFAR(uFAR, localSEID, upf, update); err != nil {
 			return sendError(err, ie.CauseRequestRejected)
 		}
@@ -308,10 +334,11 @@ func (pConn *PFCPConn) handleSessionModificationRequest(msg message.Message) (me
 
 		err = session.UpdateFAR(&f, &endMarkerList)
 		if err != nil {
-			logger.PfcpLog.Errorln("session PDR update failed", err)
-			continue
+			logger.PfcpLog.Errorf("session FAR update failed: %v", err)
+			return sendError(err, ie.CauseRequestRejected)
 		}
 
+		// Add the successfully updated FAR to be pushed to the datapath.
 		addFARs = append(addFARs, f)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind bug fix


**What this PR does / why we need it**:
This PR fixes a bug in the PFCP session modification logic where the UPF was not sending the correct cause value for an invalid Forwarding Policy ID. 

When receiving a PFCP Session Modification Request attempting to update a non-existent FAR, the UPF would respond with a generic cause like "Reason not specified (64)". According to 3GPP TS 29.244, the correct behavior is to reject the request with the specific cause "Invalid Forwarding Policy (70)".

This change introduces a validation check within the handleSessionModificationRequest function to verify that the FAR exists for the session before applying an update. If the FAR ID is not found, the UPF now correctly sends a modification failure response with cause 70. This ensures proper standards compliance and provides more accurate error reporting to the SMF.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#47](https://github.com/5GC-DEV/upf-cdac/issues/47)

**Test Report Added?**:
> /kind TESTED


**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
NA

**Special notes for your reviewer**:
NIL
