### PR TITLE
Fix missing imports in BESS scripts causing pod initialization failure

### DIFF
--- a/Dockerfile_CDAC
+++ b/Dockerfile_CDAC
@@ -3,7 +3,7 @@
 # Copyright 2019-present Intel Corporation
 
 # Stage bess-build: fetch BESS dependencies & pre-reqs
-FROM docker.io/cdac5gc/bess_build:250926 AS bess-build
+FROM docker.io/cdac5gc/bess_build:251121 AS bess-build
 ARG CPU=native
 ARG BESS_COMMIT=cdacmaster
 ENV PLUGINS_DIR=plugins

--- a/conf/ports.py
+++ b/conf/ports.py
@@ -7,6 +7,13 @@ import inspect
 import sys
 
 from conf.parser import MAX_GATES
+from conf.utils import (
+    peer_by_interface,
+    alias_by_interface, 
+    mac_by_interface,
+    ips_by_interface,
+    mac2hex
+)
 
 def setup_globals():
     caller_frame = inspect.stack()[1][0]

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -9,6 +9,7 @@ import logging
 import signal
 import sys
 import time
+import errno
 from collections import defaultdict
 from dataclasses import dataclass, field
 from threading import Lock, Thread

--- a/conf/up4.bess
+++ b/conf/up4.bess
@@ -4,6 +4,7 @@
 # Copyright 2019 Intel Corporation
 
 from conf.parser import *
+from conf.utils import *
 from conf.gtp_echo import *
 import conf.ports as port
 import conf.sim as sim

--- a/ptf/tests/linerate/mbr.py
+++ b/ptf/tests/linerate/mbr.py
@@ -9,7 +9,7 @@ from trex_stl_lib.api import STLPktBuilder, STLStream, STLTXCont
 from trex_test import TrexTest
 from trex_utils import (get_flow_stats, start_and_monitor_port_stats )
 
-from common import ( UE_IP_START, UE_COUNT, N3_IP, GNB_IP, PDN_IP, UPF_CORE_MAC, UPF_ACCESS_MAC, UPF_CORE_PORT, UPF_ACCESS_PORT, ACTION_FORWARD, DST_ACCESS, DST_CORE,
+from common import ( UE_IP_START, N3_IP, GNB_IP, PDN_IP, UPF_CORE_MAC, UPF_ACCESS_MAC, UPF_CORE_PORT, UPF_ACCESS_PORT, ACTION_FORWARD, DST_ACCESS, DST_CORE,
     GATE_METER, K, M, PKT_SIZE_L, CORE, ACCESS, GTPU_PORT, to_readable )
 
 class AppMbrTest(TrexTest, GrpcTest):

--- a/ptf/tests/linerate/qos_metrics.py
+++ b/ptf/tests/linerate/qos_metrics.py
@@ -11,9 +11,7 @@ from pkt_utils import GTPU_PORT
 from trex_stl_lib.api import STLVM, STLPktBuilder, STLStream, STLTXCont
 from trex_test import TrexTest
 
-from common import ( UE_IP_START, UE_COUNT, N3_IP, GNB_IP, PDN_IP, UPF_CORE_MAC, UPF_ACCESS_MAC, UPF_CORE_PORT, UPF_ACCESS_PORT, ACTION_FORWARD, DST_ACCESS, DST_CORE,
-    GATE_METER, K, M, PKT_SIZE_L, CORE, ACCESS, GTPU_PORT, to_readable )
-
+from common import ( UE_IP_START, UE_COUNT, N3_IP, GNB_IP, UPF_CORE_MAC, UPF_CORE_PORT, UPF_ACCESS_PORT, ACTION_FORWARD, DST_ACCESS, PKT_SIZE_L, CORE, GTPU_PORT)
 
 class PerFlowQosMetricsTest(TrexTest, GrpcTest):
     """


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
This PR resolves a NameError crash causing the UPF pod to get stuck in CrashLoopBackOff during initialization.

The BESS entry scripts (upf.bess and conf/closed_loop.bess) were relying on a transitive dependency. conf/parser.py contained a wildcard import (from conf.utils import *), which implicitly re-exported utility functions like ips_by_interface and mac_by_interface.
Refactoring parser.py to use specific imports broke this dependency chain, leaving the BESS scripts unable to find the necessary utility functions.

- Decoupled Dependencies: Added explicit from conf.utils import * statements to upf.bess and conf/closed_loop.bess. These scripts now directly import the tools they need.
- Code Cleanup: Refactored conf/parser.py to remove the wildcard import and only import the specific functions it requires (get_env, get_json_conf).

This ensures the UPF initializes correctly and improves code hygiene by removing hidden dependencies.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#56 ](https://github.com/5GC-DEV/upf-cdac/issues/56)

**Test Report Added?**:
 /kind TESTED


**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
NA

**Special notes for your reviewer**:
NIL
