### PR TITLE
feat: add per-UE throughput PM counter

### DIFF
--- a/Dockerfile_CDAC
+++ b/Dockerfile_CDAC
@@ -3,7 +3,7 @@
 # Copyright 2019-present Intel Corporation
 
 # Stage bess-build: fetch BESS dependencies & pre-reqs
-FROM docker.io/cdac5gc/bess_build:260417 AS bess-build
+FROM docker.io/cdac5gc/bess_build:260518 AS bess-build
 ARG CPU=native
 ARG BESS_COMMIT=cdacmaster
 ENV PLUGINS_DIR=plugins

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -557,7 +557,7 @@ func (b *bess) SessionStats(pc *PfcpNodeCollector, ch chan<- prometheus.Metric) 
 	}
 
 	// Prepare session stats.
-	createStats := func(preResp, postResp *pb.FlowMeasureReadResponse) {
+	createStats := func(preResp, postResp *pb.FlowMeasureReadResponse, direction string) {
 		for i := 0; i < len(postResp.Statistics); i++ {
 			var pre *pb.FlowMeasureReadResponse_Statistic
 
@@ -606,6 +606,13 @@ func (b *bess) SessionStats(pc *PfcpNodeCollector, ch chan<- prometheus.Metric) 
 				ueIpString,
 			)
 			ch <- prometheus.MustNewConstMetric(
+				pc.ueTrafficBytes,       // New descriptor
+				prometheus.CounterValue, // Counter type
+				float64(post.TotalBytes),
+				ueIpString, // Label: ue_ip
+				direction,  // Label: direction
+			)
+			ch <- prometheus.MustNewConstMetric(
 				pc.sessionRxPackets,
 				prometheus.GaugeValue,
 				float64(pre.TotalPackets),
@@ -650,8 +657,8 @@ func (b *bess) SessionStats(pc *PfcpNodeCollector, ch chan<- prometheus.Metric) 
 		}
 	}
 
-	createStats(&qosStatsInResp, &postUlQosStatsResp)
-	createStats(&qosStatsInResp, &postDlQosStatsResp)
+	createStats(&qosStatsInResp, &postUlQosStatsResp, "uplink")
+	createStats(&qosStatsInResp, &postDlQosStatsResp, "downlink")
 
 	return
 }

--- a/pfcpiface/metrics/interface.go
+++ b/pfcpiface/metrics/interface.go
@@ -37,6 +37,13 @@ type Session struct {
 	Duration  float64
 }
 
+type UETraffic struct {
+	NodeID    string
+	UEIP      string
+	Direction string // "uplink" or "downlink"
+	Bytes     uint64
+}
+
 func NewSession(nodeID string) *Session {
 	return &Session{
 		NodeID:    nodeID,
@@ -51,5 +58,6 @@ func (s *Session) Delete() {
 type InstrumentPFCP interface {
 	SaveMessages(m *Message)
 	SaveSessions(s *Session)
+	SaveUEThroughput(t *UETraffic)
 	Stop() error
 }

--- a/pfcpiface/metrics/prometheus.go
+++ b/pfcpiface/metrics/prometheus.go
@@ -15,6 +15,8 @@ type Service struct {
 
 	sessions        *prometheus.GaugeVec
 	sessionDuration *prometheus.HistogramVec
+
+	ueThroughput *prometheus.CounterVec
 }
 
 func NewPrometheusService() (*Service, error) {
@@ -68,12 +70,23 @@ func NewPrometheusService() (*Service, error) {
 		return nil, err
 	}
 
+	ueThroughput := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "upf_ue_throughput_bytes",
+		Help: "Total bytes transferred per UE",
+	}, []string{"node_id", "ue_ip", "direction"})
+
+	if err := prometheus.Register(ueThroughput); err != nil {
+		return nil, err
+	}
+
 	s := &Service{
 		msgCount:    msgCount,
 		msgDuration: msgDuration,
 
 		sessions:        sessions,
 		sessionDuration: sessionDuration,
+
+		ueThroughput: ueThroughput,
 	}
 
 	return s, nil
@@ -94,11 +107,16 @@ func (s *Service) SaveSessions(sess *Session) {
 	s.sessionDuration.WithLabelValues(sess.NodeID).Observe(sess.Duration)
 }
 
+func (s *Service) SaveUEThroughput(t *UETraffic) {
+	s.ueThroughput.WithLabelValues(t.NodeID, t.UEIP, t.Direction).Add(float64(t.Bytes))
+}
+
 func (s *Service) Stop() error {
 	prometheus.Unregister(s.msgCount)
 	prometheus.Unregister(s.msgDuration)
 	prometheus.Unregister(s.sessions)
 	prometheus.Unregister(s.sessionDuration)
+	prometheus.Unregister(s.ueThroughput)
 
 	return nil
 }

--- a/pfcpiface/telemetry.go
+++ b/pfcpiface/telemetry.go
@@ -127,6 +127,7 @@ type PfcpNodeCollector struct {
 	sessionRxPackets      *prometheus.Desc
 	sessionDroppedPackets *prometheus.Desc
 	sessionTxBytes        *prometheus.Desc
+	ueTrafficBytes        *prometheus.Desc
 }
 
 func NewPFCPNodeCollector(node *PFCPNode) *PfcpNodeCollector {
@@ -147,6 +148,10 @@ func NewPFCPNodeCollector(node *PFCPNode) *PfcpNodeCollector {
 		sessionRxPackets: prometheus.NewDesc(prometheus.BuildFQName("upf", "session", "rx_packets"),
 			"Shows the total number of packets received for a given session in UPF",
 			[]string{"fseid", "pdr", "ue_ip"}, nil,
+		),
+		ueTrafficBytes: prometheus.NewDesc(prometheus.BuildFQName("upf", "ue", "traffic_bytes"),
+			"Total bytes transferred per UE and direction",
+			[]string{"ue_ip", "direction"}, nil,
 		),
 		sessionDroppedPackets: prometheus.NewDesc(prometheus.BuildFQName("upf", "session", "dropped_packets"),
 			"Shows the number of packets dropped for a given session in UPF",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind new feature

**What this PR does / why we need it**:
Adds upf_ue_traffic_bytes{ue_ip, direction} Prometheus counter by querying FlowMeasure BESS modules via flip/read cycle and resolving fseid to UE IP from the PFCP session store. Enables per-UE uplink/downlink throughput monitoring via rate(upf_ue_traffic_bytes[1m]).

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#66](https://github.com/5GC-DEV/upf-cdac/issues/66)

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
NA

**Special notes for your reviewer**:
NIL